### PR TITLE
Added hotkey for Alt+P

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,14 @@
-'use strict';
-
 chrome.browserAction.onClicked.addListener(currentTab => {
+	PopoutTab(currentTab);
+});
+
+chrome.commands.onCommand.addListener(command => {
+	if(command == "popout_action") {
+     PopoutTab(-1);
+	}
+});
+
+function PopoutTab(currentTab){
   chrome.tabs.query({ currentWindow: true, highlighted: true },
     highlightedTabs => {
       chrome.windows.create({tabId: highlightedTabs[0].id},
@@ -10,4 +18,4 @@ chrome.browserAction.onClicked.addListener(currentTab => {
           chrome.tabs.update(currentTab.id, { active: true });
         });
     })
-});
+}

--- a/manifest.json
+++ b/manifest.json
@@ -5,14 +5,18 @@
   "manifest_version": 2,
   "background": {
     "persistent": true,
-    "scripts": [
-      "background.js"
-    ]
+    "scripts":["background.js"]
   },
   "offline_enabled": true,
   "browser_action": {
     "default_title": "Pop out tabs to new window"
+  },
+  "commands":{
+    "popout_action": {
+      "suggested_key": {
+          "default": "Alt+P"
+        },
+        "description": "Pop out tabs to new window"
+     }
   }
-
-  
 }


### PR DESCRIPTION
Can now use shortcut "Alt+P" to popout window rather than having to press chrome icon, this allows the extension to be hidden in menu and still be usable.

Btw. If accepted please can you publish to the listing in the store, I would like this feature without the annoying chrome developer popup.